### PR TITLE
Changes url and adds config for access key for ipstack

### DIFF
--- a/config.php
+++ b/config.php
@@ -16,3 +16,6 @@ $pushover_apitoken = null;
 
 // Specify slack.com webhook to notiy when a new incident occurs
 $slack_webhook_url = null;
+
+// Specify access key to ipstach (sign up free at https://ipstack.com/signup/free 100requests/month)
+$ipstack_access_key = null;

--- a/public/api.php
+++ b/public/api.php
@@ -7,7 +7,7 @@ if (!in_array($action, array('geoip', 'useragent'))) {
 if ($action == "geoip") {
   $ip = $_GET['ip'];
   $parts = explode(",", $_GET['ip']);
-  $url = "http://freegeoip.net/json/" . rawurlencode($parts[0]);
+  $url = 'http://api.ipstack.com/' . rawurlencode($parts[0]) . '?access_key=' . $ipstack_access_key;
   $json = file_get_contents($url);
   $data = json_decode($json, true);
   $response = array(


### PR DESCRIPTION
freegeoip.net is no longer available
ipstack seems to have replaced their service.

This pull requests changes the url to ipstack and introduces a new config to insert the needed access key to use their service.